### PR TITLE
feat: add nix flake with default package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,16 @@ jobs:
       - name: Run benchmarks
         run: ./build/benches/ghostclaw_benchmarks || true
 
+  nix-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: cachix/install-nix-action@v31
+
+      - name: Build
+        run: nix build --print-build-logs
+
   coverage:
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ telegram-log.txt
 # Build artifacts
 compile_commands.json
 
+# Nix
+/result
+
 # Test files (keep in repo but ignore local test configs)
 test-config.toml
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1771008912,
+        "narHash": "sha256-gf2AmWVTs8lEq7z/3ZAsgnZDhWIckkb+ZnAo5RzSxJg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a82ccc39b39b621151d6732718e3e250109076fa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,52 @@
+{
+  description = "ghostclaw - fast, ultra-lightweight AI assistant infrastructure in C++";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in
+      {
+        packages.default = pkgs.stdenv.mkDerivation {
+          pname = "ghostclaw";
+          version = "0.1.0";
+
+          src = ./.;
+
+          nativeBuildInputs = with pkgs; [
+            cmake
+            ninja
+            pkg-config
+          ];
+
+          buildInputs = with pkgs; [
+            curl
+            openssl
+            sqlite
+          ];
+
+          cmakeFlags = [
+            "-DCMAKE_BUILD_TYPE=Release"
+            "-DGHOSTCLAW_BUILD_BENCHMARKS=OFF"
+          ];
+
+          installPhase = ''
+            runHook preInstall
+            install -Dm755 ghostclaw $out/bin/ghostclaw
+            runHook postInstall
+          '';
+
+          meta = with pkgs.lib; {
+            description = "Fast, ultra-lightweight, fully autonomous AI assistant infrastructure";
+            homepage = "https://github.com/anomalyco/ghostclaw";
+            license = licenses.mit;
+            mainProgram = "ghostclaw";
+          };
+        };
+      });
+}

--- a/src/channels/whatsapp/whatsapp.cpp
+++ b/src/channels/whatsapp/whatsapp.cpp
@@ -4,6 +4,7 @@
 #include "ghostclaw/common/fs.hpp"
 #include "ghostclaw/common/json_util.hpp"
 
+#include <algorithm>
 #include <sstream>
 
 namespace ghostclaw::channels::whatsapp {


### PR DESCRIPTION
Add flake.nix that builds the ghostclaw binary using cmake/ninja with curl, openssl, and sqlite dependencies. Also fix a missing <algorithm> include in whatsapp.cpp required by GCC 15.